### PR TITLE
🛡️ Sentinel: Mask MQTT password in logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-01-29 - Masking sensitive credentials in logs
+**Vulnerability:** The MQTT password (`MQTT_PSWD`) was logged in plain text when the addon failed to start due to incomplete MQTT configuration.
+**Learning:** Error-handling paths that log configuration state for debugging can accidentally leak sensitive data if not carefully audited.
+**Prevention:** Always mask sensitive variables (passwords, tokens, keys) when logging configuration state. Use a helper like `bashio::var.has_value` to check for presence without revealing content.

--- a/addon/run.sh
+++ b/addon/run.sh
@@ -78,7 +78,11 @@ if [ -z "${MQTT_HOST}" ] || \
   bashio::log.blue "mqtt_host = $MQTT_HOST"
   bashio::log.blue "mqtt_port = $MQTT_PORT"
   bashio::log.blue "mqtt_user = $MQTT_USER"
-  bashio::log.blue "mqtt_pwd  = $MQTT_PSWD"
+  if bashio::var.has_value "${MQTT_PSWD}"; then
+    bashio::log.blue "mqtt_pwd  = ******"
+  else
+    bashio::log.blue "mqtt_pwd  = "
+  fi
   bashio::exit.nok "MQTT broker connection not fully configured"
 fi
 


### PR DESCRIPTION
Identified and fixed a security vulnerability where the MQTT password was logged in plain text in `addon/run.sh`. This occurred when the addon checked for required MQTT parameters and found some were missing, leading it to log all parameters (including the password) for debugging. I have updated the script to mask the password with `******` if it is present, ensuring that sensitive information is not exposed in the logs. I also added a Sentinel security journal entry in `.jules/sentinel.md` to document this learning.

---
*PR created automatically by Jules for task [14574609337987522527](https://jules.google.com/task/14574609337987522527) started by @ChristopheHD*