### PR TITLE
🛡️ Sentinel: Harden run.sh script

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-02-03 - [Bash Hardening Regression]
+**Vulnerability:** Incomplete hardening of shell scripts leading to crashes.
+**Learning:** Adding `set -u` (nounset) to an existing bash script without initializing all variables at the top can lead to functional regressions, especially when variables are optionally set from configuration or external services.
+**Prevention:** Always initialize all variables to empty strings at the top of a script when using `set -u`, or use the ${VAR:-} expansion syntax.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,0 @@
-## 2024-02-03 - [Bash Hardening Regression]
-**Vulnerability:** Incomplete hardening of shell scripts leading to crashes.
-**Learning:** Adding `set -u` (nounset) to an existing bash script without initializing all variables at the top can lead to functional regressions, especially when variables are optionally set from configuration or external services.
-**Prevention:** Always initialize all variables to empty strings at the top of a script when using `set -u`, or use the ${VAR:-} expansion syntax.

--- a/addon/run.sh
+++ b/addon/run.sh
@@ -1,4 +1,15 @@
 #!/usr/bin/with-contenv bashio
+set -e
+set -u
+
+# Initialize variables to ensure they are defined (for set -u)
+MQTT_HOST=""
+MQTT_PORT=""
+MQTT_USER=""
+MQTT_PSWD=""
+ENOCEAN_PORT=""
+EEP_FILE=""
+DEBUG_FLAG=""
 
 bashio::config.require 'device_file'
 bashio::config.require 'mqtt.discovery_prefix'
@@ -12,6 +23,9 @@ bashio::log.green "Preparing to start..."
 export CONFIG_FILE="/data/enoceanmqtt.conf"
 export DB_FILE="/data/enoceanmqtt_db.json"
 DEVICE_FILE="$(bashio::config 'device_file')"
+if [ ! -f "$DEVICE_FILE" ]; then
+    bashio::exit.nok "Device file not found at $DEVICE_FILE"
+fi
 export DEVICE_FILE
 LOG_FILE="$(bashio::config 'logging.log_file')"
 export LOG_FILE
@@ -20,7 +34,6 @@ export MAPPING_FILE
 bashio::log.blue "Retrieved devices file: $DEVICE_FILE"
 
 # Retrieve EnOcean key connection parameters
-ENOCEAN_PORT=""
 if ! bashio::config.is_empty 'enocean_tcp'; then
   ENOCEAN_PORT="$(bashio::config 'enocean_tcp')"
   bashio::log.blue "TCP EnOcean key = $ENOCEAN_PORT"
@@ -33,25 +46,17 @@ fi
 export ENOCEAN_PORT
 
 # Retrieve MQTT connection parameters
-MQTT_HOST=""
-MQTT_PORT=""
-MQTT_USER=""
-MQTT_PSWD=""
 if ! bashio::config.is_empty 'mqtt.host'; then
   MQTT_HOST="$(bashio::config 'mqtt.host')"
-  export MQTT_HOST
 fi
 if ! bashio::config.is_empty 'mqtt.port'; then
   MQTT_PORT="$(bashio::config 'mqtt.port')"
-  export MQTT_PORT
 fi
 if ! bashio::config.is_empty 'mqtt.user'; then
   MQTT_USER="$(bashio::config 'mqtt.user')"
-  export MQTT_USER
 fi
 if ! bashio::config.is_empty 'mqtt.pwd'; then
   MQTT_PSWD="$(bashio::config 'mqtt.pwd')"
-  export MQTT_PSWD
 fi
 
 if [ -z "${MQTT_HOST}" ] && \
@@ -60,13 +65,9 @@ if [ -z "${MQTT_HOST}" ] && \
    [ -z "${MQTT_PSWD}" ]; then
   if bashio::var.has_value "$(bashio::services 'mqtt')"; then
     MQTT_HOST="$(bashio::services 'mqtt' 'host')"
-    export MQTT_HOST
     MQTT_PORT="$(bashio::services 'mqtt' 'port')"
-    export MQTT_PORT
     MQTT_USER="$(bashio::services 'mqtt' 'username')"
-    export MQTT_USER
     MQTT_PSWD="$(bashio::services 'mqtt' 'password')"
-    export MQTT_PSWD
   fi
 fi
 
@@ -88,12 +89,14 @@ fi
 
 # Debug parameter
 if bashio::var.true "$(bashio::config 'logging.debug')"; then
-  export DEBUG_FLAG="--debug"
+  DEBUG_FLAG="--debug"
 else
-  export DEBUG_FLAG=""
+  DEBUG_FLAG=""
 fi
 
 # Create enoceanmqtt configuration file
+# Use umask to ensure the configuration file is created with restrictive permissions
+umask 0077
 MQTT_PREFIX=$(bashio::config 'mqtt.prefix')
 MQTT_DISCOVERY_PREFIX=$(bashio::config 'mqtt.discovery_prefix')
 MQTT_PREFIX="${MQTT_PREFIX%/}/"
@@ -114,7 +117,7 @@ MQTT_DISCOVERY_PREFIX="${MQTT_DISCOVERY_PREFIX%/}/"
   echo "mqtt_prefix           = ${MQTT_PREFIX}"
   echo "mqtt_user             = ${MQTT_USER}"
   echo "mqtt_pwd              = ${MQTT_PSWD}"
-  echo "mqtt_debug            = $(bashio::config 'debug')"
+  echo "mqtt_debug            = $(bashio::config 'logging.debug')"
   echo ""
   cat "$DEVICE_FILE"
 } > "${CONFIG_FILE}"
@@ -126,7 +129,7 @@ rm -f "$LOG_FILE"
 if ! bashio::config.is_empty 'mapping_files.eep_file'; then
    EEP_FILE=$(bashio::config 'mapping_files.eep_file')
    EEP_FILE_LOCATION=$(find /app/venv/lib/ -name "EEP.xml" -print -quit 2>/dev/null)
-   if [ -e "$EEP_FILE" ]; then
+   if [ -f "$EEP_FILE" ]; then
       bashio::log.green "Installing custom EEP.xml ..."
       cp -f "$EEP_FILE" "$EEP_FILE_LOCATION"
    else


### PR DESCRIPTION
This PR hardens the `run.sh` script to improve the security and robustness of the EnOcean MQTT addon.

### 🛡️ Sentinel: Secure Configuration and Input Handling

🚨 **Severity:** MEDIUM (Defense in Depth)

💡 **Vulnerability:**
1. The generated configuration file `/data/enoceanmqtt.conf` contained the MQTT password in plaintext and was created with default permissions, making it potentially readable by other processes in the container.
2. Sensitive MQTT credentials were exported as environment variables, making them visible to child processes.
3. User-provided file paths were used without validation, which could lead to issues with non-regular files.
4. Inconsistent retrieval of the `debug` configuration value.

🎯 **Impact:**
- Potential exposure of MQTT credentials to unauthorized processes or logs.
- Script failures or unexpected behavior when encountering non-regular files.
- Incomplete debug logging due to configuration typos.

🔧 **Fix:**
- Added `set -e` and `set -u` to the script.
- Used `umask 0077` before creating the configuration file.
- Added `[ -f "$FILE" ]` checks for input files.
- Removed `export` for `MQTT_PSWD` and other MQTT variables.
- Fixed the `mqtt_debug` configuration key.
- Initialized all variables at the top of the script.

✅ **Verification:**
- Verified syntax with `bash -n`.
- Manual code review of the logic to ensure all variables are defined and handled securely.

---
*PR created automatically by Jules for task [16506336147071739146](https://jules.google.com/task/16506336147071739146) started by @ChristopheHD*