### PR TITLE
🛡️ Sentinel: Harden addon/run.sh security

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,0 @@
-## 2025-05-15 - Hardening Add-on Entrypoint Script
-**Vulnerability:** Potential exposure of secrets in configuration files and environment.
-**Learning:** Home Assistant add-ons often generate configuration files at runtime. If not careful, these files can be created with overly permissive permissions. Also, exporting sensitive data (or even non-sensitive data that doesn't need to be exported) to the environment of sub-processes increases the attack surface. Using `echo` to write secrets to files can also lead to issues if the secret contains special characters that `echo` might interpret.
-**Prevention:** Use a global `umask 0077` in entrypoint scripts to ensure all generated files are private by default. Use `printf` with `%s` format specifiers instead of `echo` for writing configuration values safely. Avoid `export` unless a variable is strictly required by the environment of a sub-process.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Hardening Add-on Entrypoint Script
+**Vulnerability:** Potential exposure of secrets in configuration files and environment.
+**Learning:** Home Assistant add-ons often generate configuration files at runtime. If not careful, these files can be created with overly permissive permissions. Also, exporting sensitive data (or even non-sensitive data that doesn't need to be exported) to the environment of sub-processes increases the attack surface. Using `echo` to write secrets to files can also lead to issues if the secret contains special characters that `echo` might interpret.
+**Prevention:** Use a global `umask 0077` in entrypoint scripts to ensure all generated files are private by default. Use `printf` with `%s` format specifiers instead of `echo` for writing configuration values safely. Avoid `export` unless a variable is strictly required by the environment of a sub-process.

--- a/addon/run.sh
+++ b/addon/run.sh
@@ -2,6 +2,9 @@
 set -e
 set -u
 
+# Set restrictive umask for the entire script
+umask 0077
+
 # Initialize variables to ensure they are defined (for set -u)
 MQTT_HOST=""
 MQTT_PORT=""
@@ -20,17 +23,14 @@ bashio::config.require 'mqtt.keepalive'
 bashio::log.green "Preparing to start..."
 
 # Set files to be used
-export CONFIG_FILE="/data/enoceanmqtt.conf"
-export DB_FILE="/data/enoceanmqtt_db.json"
+CONFIG_FILE="/data/enoceanmqtt.conf"
+DB_FILE="/data/enoceanmqtt_db.json"
 DEVICE_FILE="$(bashio::config 'device_file')"
 if [ ! -f "$DEVICE_FILE" ]; then
     bashio::exit.nok "Device file not found at $DEVICE_FILE"
 fi
-export DEVICE_FILE
 LOG_FILE="$(bashio::config 'logging.log_file')"
-export LOG_FILE
 MAPPING_FILE="$(bashio::config 'mapping_files.mapping_file')"
-export MAPPING_FILE
 bashio::log.blue "Retrieved devices file: $DEVICE_FILE"
 
 # Retrieve EnOcean key connection parameters
@@ -43,7 +43,6 @@ elif ! bashio::config.is_empty 'enocean_port'; then
 else
   bashio::exit.nok "No EnOcean key configured"
 fi
-export ENOCEAN_PORT
 
 # Retrieve MQTT connection parameters
 if ! bashio::config.is_empty 'mqtt.host'; then
@@ -95,30 +94,28 @@ else
 fi
 
 # Create enoceanmqtt configuration file
-# Use umask to ensure the configuration file is created with restrictive permissions
-umask 0077
 MQTT_PREFIX=$(bashio::config 'mqtt.prefix')
 MQTT_DISCOVERY_PREFIX=$(bashio::config 'mqtt.discovery_prefix')
 MQTT_PREFIX="${MQTT_PREFIX%/}/"
 MQTT_DISCOVERY_PREFIX="${MQTT_DISCOVERY_PREFIX%/}/"
 
 {
-  echo "[CONFIG]"
-  echo "enocean_port          = ${ENOCEAN_PORT}"
-  echo "log_packets           = $(bashio::config 'logging.log_packets')"
-  echo "overlay               = HA"
-  echo "db_file               = ${DB_FILE}"
-  echo "mapping_file          = ${MAPPING_FILE}"
-  echo "mqtt_discovery_prefix = ${MQTT_DISCOVERY_PREFIX}"
-  echo "mqtt_host             = ${MQTT_HOST}"
-  echo "mqtt_port             = ${MQTT_PORT}"
-  echo "mqtt_client_id        = $(bashio::config 'mqtt.client_id')"
-  echo "mqtt_keepalive        = $(bashio::config 'mqtt.keepalive')"
-  echo "mqtt_prefix           = ${MQTT_PREFIX}"
-  echo "mqtt_user             = ${MQTT_USER}"
-  echo "mqtt_pwd              = ${MQTT_PSWD}"
-  echo "mqtt_debug            = $(bashio::config 'logging.debug')"
-  echo ""
+  printf "[CONFIG]\n"
+  printf "enocean_port          = %s\n" "${ENOCEAN_PORT}"
+  printf "log_packets           = %s\n" "$(bashio::config 'logging.log_packets')"
+  printf "overlay               = HA\n"
+  printf "db_file               = %s\n" "${DB_FILE}"
+  printf "mapping_file          = %s\n" "${MAPPING_FILE}"
+  printf "mqtt_discovery_prefix = %s\n" "${MQTT_DISCOVERY_PREFIX}"
+  printf "mqtt_host             = %s\n" "${MQTT_HOST}"
+  printf "mqtt_port             = %s\n" "${MQTT_PORT}"
+  printf "mqtt_client_id        = %s\n" "$(bashio::config 'mqtt.client_id')"
+  printf "mqtt_keepalive        = %s\n" "$(bashio::config 'mqtt.keepalive')"
+  printf "mqtt_prefix           = %s\n" "${MQTT_PREFIX}"
+  printf "mqtt_user             = %s\n" "${MQTT_USER}"
+  printf "mqtt_pwd              = %s\n" "${MQTT_PSWD}"
+  printf "mqtt_debug            = %s\n" "$(bashio::config 'logging.debug')"
+  printf "\n"
   cat "$DEVICE_FILE"
 } > "${CONFIG_FILE}"
 bashio::log.debug "Configuration written to ${CONFIG_FILE}"


### PR DESCRIPTION
This PR enhances the security of the Home Assistant add-on's entrypoint script (`run.sh`) by:
1. Setting a global `umask 0077` at the top of the script. This ensures that any files created by the script (such as `/data/enoceanmqtt.conf`, `/data/enoceanmqtt_db.json`, and the log file) are created with restrictive permissions (only readable/writable by the owner) by default.
2. Replacing `echo` with `printf` when generating the configuration file. `printf` with `%s` format specifiers is much safer as it treats variable contents as literal strings, preventing any potential shell interpretation of special characters that might be present in the MQTT password or other configuration values.
3. Removing the `export` keyword from variables that do not need to be in the environment of the `enoceanmqtt` sub-process. These variables are already passed to the application via command-line arguments or the configuration file it reads.

These changes reduce the attack surface and prevent accidental exposure of sensitive information.

---
*PR created automatically by Jules for task [13065112815815755103](https://jules.google.com/task/13065112815815755103) started by @ChristopheHD*